### PR TITLE
Partial fix for issue #3560 Reharvest not recreating views

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -110,6 +110,16 @@ def resource_update(context, data_dict):
 
     resource = _get_action('resource_show')(context, {'id': id})
 
+    #  Add the default views to the new resource
+    logic.get_action('resource_create_default_resource_views')(
+        {'model': context['model'],
+         'user': context['user'],
+         'ignore_auth': True
+         },
+        {'resource': resource,
+         'package': updated_pkg_dict
+         })
+
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_update(context, resource)
 


### PR DESCRIPTION
   - update resource will now create missing recline CSV view.

Fixes #

### Proposed fixes:

Partial fix for not creating default views.
The default CSV view is now created when a resource is updated.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
