### PR TITLE
Fix for issue #3560 Reharvest not recreating views

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -315,8 +315,16 @@ def package_update(context, data_dict):
 
     return_id_only = context.get('return_id_only', False)
 
-    # Make sure that a user provided schema is not used on package_show
+    # Make sure that a user provided schema is not used in create_views
+    # and on package_show
     context.pop('schema', None)
+
+    # Create default views for resources if necessary
+    if data.get('resources'):
+        logic.get_action('package_create_default_resource_views')(
+            {'model': context['model'], 'user': context['user'],
+             'ignore_auth': True},
+            {'package': data})
 
     # we could update the dataset so we should still be able to read it.
     context['ignore_auth'] = True


### PR DESCRIPTION
   - Change package_update so that it now creates the default views

Fixes #3560

### Proposed fixes:

Core package_update now creates the default views in the same way as package_create.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
